### PR TITLE
Compare listings feature in collections detail

### DIFF
--- a/homepare/src/App.css
+++ b/homepare/src/App.css
@@ -73,3 +73,9 @@ hr.rounded-divider-in-user-collections {
   font-size:x-small;
   margin: 15px;
 }
+
+button {
+  border: solid black 2px;
+  padding: 3px;
+  margin: 5px;
+}

--- a/homepare/src/CollectionDetail.jsx
+++ b/homepare/src/CollectionDetail.jsx
@@ -1,7 +1,7 @@
 import { ListingDetails } from "./ListingDetails";
 import { DetailsCard } from "./detailsCard";
 import { ListingInput } from "./listingInput";
-import { ComparisonTable } from "./comparisonTable"
+import { ComparisonTable } from "./comparisonTable";
 import homeData from "./data/homes.json";
 import { useState } from "react";
 import { useDisclosure } from "@mantine/hooks";
@@ -17,8 +17,12 @@ export function CollectionDetail() {
   );
   //the value inside new Array is hardcoded for demo, it should be updated to what the length of listings in the collection
   const [selectedThumbnails, setSelectedThumbnails] = useState([]);
+  const [
+    thumbnailModalOpened,
+    { open: thumbnailModalOpen, close: thumbnailModalClose },
+  ] = useDisclosure(false);
   const [opened, { open, close }] = useDisclosure(false);
-  
+  //this useDisclosure is for Mantine
 
   const handleCheckChange = () => {
     setCompareChecked(!compareChecked);
@@ -31,6 +35,7 @@ export function CollectionDetail() {
 
     setlistingCheckBoxes(updatedListingCheckBoxes);
     setSelectedThumbnails();
+    //we need to send information from each checked box that identifies
     console.log("selectedThumbnails", selectedThumbnails);
   };
 
@@ -74,13 +79,13 @@ export function CollectionDetail() {
       />
       <label>Compare?</label>
       {!compareChecked && (
-        <Modal opened={opened} onClose={close} centered>
+        <Modal opened={thumbnailModalOpened} onClose={thumbnailModalClose} centered>
           <DetailsCard />
         </Modal>
       )}
 
       <div className="thumnail-grid-in-collections-detail">
-        <div onClick={open} className="listing-thumbnail-in-collections-detail">
+        <div onClick={thumbnailModalOpen} className="listing-thumbnail-in-collections-detail">
           <img
             src={homeData.value[0].Media[0].Thumbnail}
             width={thumbWidth}
@@ -99,7 +104,7 @@ export function CollectionDetail() {
           )}
         </div>
 
-        <div onClick={open} className="listing-thumbnail">
+        <div onClick={thumbnailModalOpen} className="listing-thumbnail">
           <img
             src={homeData.value[0].Media[0].Thumbnail}
             width={thumbWidth}
@@ -118,7 +123,7 @@ export function CollectionDetail() {
           )}
         </div>
 
-        <div onClick={open} className="listing-thumbnail">
+        <div onClick={thumbnailModalOpen} className="listing-thumbnail">
           <img
             src={homeData.value[0].Media[0].Thumbnail}
             width={thumbWidth}
@@ -137,7 +142,7 @@ export function CollectionDetail() {
           )}
         </div>
 
-        <div onClick={open} className="listing-thumbnail">
+        <div onClick={thumbnailModalOpen} className="listing-thumbnail">
           <img
             src={homeData.value[0].Media[0].Thumbnail}
             width={thumbWidth}

--- a/homepare/src/CollectionDetail.jsx
+++ b/homepare/src/CollectionDetail.jsx
@@ -13,7 +13,7 @@ export function CollectionDetail() {
 
   const [compareChecked, setCompareChecked] = useState(false);
   const [listingCheckBoxes, setlistingCheckBoxes] = useState(
-    new Array(4).fill(false)
+    new Array(homeData.homes.length).fill(false)
   );
   //the value inside new Array is hardcoded for demo, it should be updated to what the length of listings in the collection
   const [
@@ -36,24 +36,6 @@ export function CollectionDetail() {
     //we need to send information from each checked box that identifies the listings
   };
 
- 
-
-
-
-  const previewSelectedThumbnails = () => {
-    //after checking which listings they want to compare
-    //the bottom of the screen pops up a modal
-    //with a compare button
-  };
-
-  const handleCompareClick = () => {
-    console.log("compare click");
-
-    //when the user hits that
-    //a full screen modal pops out
-    //with the comparison table
-  };
-
   return (
     <>
       <p>
@@ -61,7 +43,7 @@ export function CollectionDetail() {
         thumbnail and address will be mapped out here
       </p>
       <h1> Collection Title </h1>
-      <button onClick={open}>Compare</button>
+      {listingCheckBoxes.find((checkedbox) => checkedbox === true) && <button onClick={open}>Compare</button>}
       <Modal
         opened={opened}
         onClose={close}
@@ -76,11 +58,6 @@ export function CollectionDetail() {
             return true;
           } return false;
         })}
-  // filter the data by listingCheckBoxes being true
-  // then send the whole data set
-  // to the compare table
-    
-
   />
       </Modal>
       <br></br>

--- a/homepare/src/CollectionDetail.jsx
+++ b/homepare/src/CollectionDetail.jsx
@@ -36,9 +36,9 @@ export function CollectionDetail() {
     //we need to send information from each checked box that identifies the listings
   };
 
-  //if listingCheckBoxes value === true
-  //then send the whole data set
-  //to the compare table
+ 
+
+
 
   const previewSelectedThumbnails = () => {
     //after checking which listings they want to compare
@@ -70,7 +70,18 @@ export function CollectionDetail() {
         radius={0}
         transitionProps={{ transition: "fade", duration: 200 }}
       >
-        <ComparisonTable />
+        <ComparisonTable 
+        homeData={homeData.homes.filter((listing, index) => 
+          {if (listingCheckBoxes[index] === true) {
+            return true;
+          } return false;
+        })}
+  // filter the data by listingCheckBoxes being true
+  // then send the whole data set
+  // to the compare table
+    
+
+  />
       </Modal>
       <br></br>
       <input

--- a/homepare/src/CollectionDetail.jsx
+++ b/homepare/src/CollectionDetail.jsx
@@ -2,7 +2,7 @@ import { ListingDetails } from "./ListingDetails";
 import { DetailsCard } from "./detailsCard";
 import { ListingInput } from "./listingInput";
 import { ComparisonTable } from "./comparisonTable";
-import homeData from "./data/homes.json";
+import homeData from "./data/homesfromDB.json";
 import { useState } from "react";
 import { useDisclosure } from "@mantine/hooks";
 import { Modal, Button } from "@mantine/core";
@@ -16,7 +16,6 @@ export function CollectionDetail() {
     new Array(4).fill(false)
   );
   //the value inside new Array is hardcoded for demo, it should be updated to what the length of listings in the collection
-  const [selectedThumbnails, setSelectedThumbnails] = useState([]);
   const [
     thumbnailModalOpened,
     { open: thumbnailModalOpen, close: thumbnailModalClose },
@@ -28,16 +27,18 @@ export function CollectionDetail() {
     setCompareChecked(!compareChecked);
   };
 
-  const handleThumbnailCheckOnChange = (position) => {
+  const handleThumbnailCheckOnChange = (listingIndex) => {
     const updatedListingCheckBoxes = listingCheckBoxes.map((listing, index) =>
-      index === position ? !listing : listing
+      index === listingIndex ? !listing : listing
     );
 
     setlistingCheckBoxes(updatedListingCheckBoxes);
-    setSelectedThumbnails();
-    //we need to send information from each checked box that identifies
-    console.log("selectedThumbnails", selectedThumbnails);
+    //we need to send information from each checked box that identifies the listings
   };
+
+  //if listingCheckBoxes value === true
+  //then send the whole data set
+  //to the compare table
 
   const previewSelectedThumbnails = () => {
     //after checking which listings they want to compare
@@ -79,38 +80,51 @@ export function CollectionDetail() {
       />
       <label>Compare?</label>
       {!compareChecked && (
-        <Modal opened={thumbnailModalOpened} onClose={thumbnailModalClose} centered>
+        <Modal
+          opened={thumbnailModalOpened}
+          onClose={thumbnailModalClose}
+          centered
+        >
           <DetailsCard />
         </Modal>
       )}
 
       <div className="thumnail-grid-in-collections-detail">
-        <div onClick={thumbnailModalOpen} className="listing-thumbnail-in-collections-detail">
-          <img
-            src={homeData.value[0].Media[0].Thumbnail}
-            width={thumbWidth}
-            height={thumbHeight}
-          />
-          <p>{homeData.value[0].UnparsedAddress}</p>
-          {compareChecked === true && (
-            <>
-              <input
-                type="checkbox"
-                checked={listingCheckBoxes[0]}
-                onChange={() => handleThumbnailCheckOnChange(0)}
+        {homeData.homes.map((listing, index) => {
+          console.log('listing', listing)
+          return (
+            <div
+              onClick={thumbnailModalOpen}
+              key="id"
+              className="listing-thumbnail-in-collections-detail"
+            >
+              <img
+                src={listing.images[0].Thumbnail}
+                width={thumbWidth}
+                height={thumbHeight}
               />
-              <label>Compare</label>
-            </>
-          )}
-        </div>
+              <p>{listing.address}</p>
+              {compareChecked === true && (
+                <>
+                  <input
+                    type="checkbox"
+                    checked={listingCheckBoxes[index]}
+                    onChange={() => handleThumbnailCheckOnChange(index)}
+                  />
+                  <label>Compare</label>
+                </>
+              )}
+            </div>
+          );
+        })}
 
-        <div onClick={thumbnailModalOpen} className="listing-thumbnail">
+        {/* <div onClick={thumbnailModalOpen} className="listing-thumbnail">
           <img
-            src={homeData.value[0].Media[0].Thumbnail}
+            src={homeData.homes[1].images[1].Thumbnail}
             width={thumbWidth}
             height={thumbHeight}
           />
-          <p>{homeData.value[0].UnparsedAddress}</p>
+          <p>{homeData.homes[1].address}</p>
           {compareChecked === true && (
             <>
               <input
@@ -125,11 +139,11 @@ export function CollectionDetail() {
 
         <div onClick={thumbnailModalOpen} className="listing-thumbnail">
           <img
-            src={homeData.value[0].Media[0].Thumbnail}
+            src={homeData.homes[2].images[2].Thumbnail}
             width={thumbWidth}
             height={thumbHeight}
           />
-          <p>{homeData.value[0].UnparsedAddress}</p>
+          <p>{homeData.homes[2].address}</p>
           {compareChecked === true && (
             <>
               <input
@@ -144,11 +158,11 @@ export function CollectionDetail() {
 
         <div onClick={thumbnailModalOpen} className="listing-thumbnail">
           <img
-            src={homeData.value[0].Media[0].Thumbnail}
+            src={homeData.homes[0].images[0].Thumbnail}
             width={thumbWidth}
             height={thumbHeight}
           />
-          <p>{homeData.value[0].UnparsedAddress}</p>
+          <p>{homeData.homes[0].address}</p>
           {compareChecked === true && (
             <>
               <input
@@ -159,7 +173,7 @@ export function CollectionDetail() {
               <label>Compare</label>
             </>
           )}
-        </div>
+        </div> */}
       </div>
     </>
   );

--- a/homepare/src/CollectionDetail.jsx
+++ b/homepare/src/CollectionDetail.jsx
@@ -1,106 +1,161 @@
-import { ListingDetails } from './ListingDetails'
-import { DetailsCard } from './detailsCard'
-import { ListingInput } from './listingInput'
-import homeData from './data/homes.json'
-import { useState } from 'react';
-import { useDisclosure } from '@mantine/hooks';
-import { Modal, Button } from '@mantine/core';
+import { ListingDetails } from "./ListingDetails";
+import { DetailsCard } from "./detailsCard";
+import { ListingInput } from "./listingInput";
+import { ComparisonTable } from "./comparisonTable"
+import homeData from "./data/homes.json";
+import { useState } from "react";
+import { useDisclosure } from "@mantine/hooks";
+import { Modal, Button } from "@mantine/core";
 
 export function CollectionDetail() {
-    const thumbWidth = "100px";
-    const thumbHeight = "100px";
+  const thumbWidth = "100px";
+  const thumbHeight = "100px";
 
-    const [compareChecked, setCompareChecked] = useState(false)
-    const [listingCheckBoxes, setlistingCheckBoxes] = useState(new Array(4).fill(false))
-    //the value inside new Array is hardcoded for demo, it should be updated to what the length of listings in the collection
-    const [selectedThumbnails, setSelectedThumbnails] = useState([])
-    const [opened, { open, close }] = useDisclosure(false);
+  const [compareChecked, setCompareChecked] = useState(false);
+  const [listingCheckBoxes, setlistingCheckBoxes] = useState(
+    new Array(4).fill(false)
+  );
+  //the value inside new Array is hardcoded for demo, it should be updated to what the length of listings in the collection
+  const [selectedThumbnails, setSelectedThumbnails] = useState([]);
+  const [opened, { open, close }] = useDisclosure(false);
+  
 
-    const handleCheckChange = () => {
-        setCompareChecked(!compareChecked)
-    }
+  const handleCheckChange = () => {
+    setCompareChecked(!compareChecked);
+  };
 
-    const handleThumbnailCheckOnChange = (position) => {
-        const updatedListingCheckBoxes = listingCheckBoxes.map((listing, index) =>
-        index === position ? !listing : listing )
+  const handleThumbnailCheckOnChange = (position) => {
+    const updatedListingCheckBoxes = listingCheckBoxes.map((listing, index) =>
+      index === position ? !listing : listing
+    );
 
-        setlistingCheckBoxes(updatedListingCheckBoxes)
-        setSelectedThumbnails()
-        console.log('selectedThumbnails', selectedThumbnails)
+    setlistingCheckBoxes(updatedListingCheckBoxes);
+    setSelectedThumbnails();
+    console.log("selectedThumbnails", selectedThumbnails);
+  };
 
+  const previewSelectedThumbnails = () => {
+    //after checking which listings they want to compare
+    //the bottom of the screen pops up a modal
+    //with a compare button
+  };
 
-    }
+  const handleCompareClick = () => {
+    console.log("compare click");
 
-    const previewSelectedThumbnails = () => {
-        //when the are clicked/checked
-        //our selected thumbnails should go up into the
-        //new selected thumbnails array
-        //and be shown as in the size auto modal
-    }
+    //when the user hits that
+    //a full screen modal pops out
+    //with the comparison table
+  };
 
-    const handleCompareClick = () => {
-        console.log('compare click')
-        //after checking which listings they want to compare
-        //user hits the compare button (ideally on the preview)
-        //and a full screen modal pops out
-        //with the comparison table
-    }
-
-    return (
-        <>
-        <p>This is the collection detail page, cards containing house image thumbnail and address will be mapped out here</p>
-        <h1> Collection Title </h1>
-        <input 
+  return (
+    <>
+      <p>
+        This is the collection detail page, cards containing house image
+        thumbnail and address will be mapped out here
+      </p>
+      <h1> Collection Title </h1>
+      <button onClick={open}>Compare</button>
+      <Modal
+        opened={opened}
+        onClose={close}
+        title="This is a fullscreen modal"
+        fullScreen
+        radius={0}
+        transitionProps={{ transition: "fade", duration: 200 }}
+      >
+        <ComparisonTable />
+      </Modal>
+      <br></br>
+      <input
         type="checkbox"
         checked={compareChecked}
         onChange={handleCheckChange}
-        /><label>Compare?</label>
-        {!compareChecked &&
+      />
+      <label>Compare?</label>
+      {!compareChecked && (
         <Modal opened={opened} onClose={close} centered>
-            <DetailsCard />
-        </Modal>}
-        
-        <div className='thumnail-grid-in-collections-detail'>
-        <div  onClick={open} className='listing-thumbnail-in-collections-detail'>
-        <img src={homeData.value[0].Media[0].Thumbnail} width={thumbWidth} height={thumbHeight}/>
-        <p>{homeData.value[0].UnparsedAddress}</p>
-        {compareChecked === true && <><input 
-        type="checkbox"
-        checked={listingCheckBoxes[0]}
-        onChange={() => handleThumbnailCheckOnChange(0)}
-        /><label>Compare</label></>}
+          <DetailsCard />
+        </Modal>
+      )}
+
+      <div className="thumnail-grid-in-collections-detail">
+        <div onClick={open} className="listing-thumbnail-in-collections-detail">
+          <img
+            src={homeData.value[0].Media[0].Thumbnail}
+            width={thumbWidth}
+            height={thumbHeight}
+          />
+          <p>{homeData.value[0].UnparsedAddress}</p>
+          {compareChecked === true && (
+            <>
+              <input
+                type="checkbox"
+                checked={listingCheckBoxes[0]}
+                onChange={() => handleThumbnailCheckOnChange(0)}
+              />
+              <label>Compare</label>
+            </>
+          )}
         </div>
 
-        <div  onClick={open} className='listing-thumbnail'>
-        <img src={homeData.value[0].Media[0].Thumbnail} width={thumbWidth} height={thumbHeight}/>
-        <p>{homeData.value[0].UnparsedAddress}</p>
-        {compareChecked === true && <><input 
-        type="checkbox"
-        checked={listingCheckBoxes[1]}
-        onChange={() => handleThumbnailCheckOnChange(1)}
-        /><label>Compare</label></>}
+        <div onClick={open} className="listing-thumbnail">
+          <img
+            src={homeData.value[0].Media[0].Thumbnail}
+            width={thumbWidth}
+            height={thumbHeight}
+          />
+          <p>{homeData.value[0].UnparsedAddress}</p>
+          {compareChecked === true && (
+            <>
+              <input
+                type="checkbox"
+                checked={listingCheckBoxes[1]}
+                onChange={() => handleThumbnailCheckOnChange(1)}
+              />
+              <label>Compare</label>
+            </>
+          )}
         </div>
 
-        <div  onClick={open} className='listing-thumbnail'>
-        <img src={homeData.value[0].Media[0].Thumbnail} width={thumbWidth} height={thumbHeight}/>
-        <p>{homeData.value[0].UnparsedAddress}</p>
-        {compareChecked === true && <><input 
-        type="checkbox"
-        checked={listingCheckBoxes[2]}
-        onChange={() => handleThumbnailCheckOnChange(2)}
-        /><label>Compare</label></>}
+        <div onClick={open} className="listing-thumbnail">
+          <img
+            src={homeData.value[0].Media[0].Thumbnail}
+            width={thumbWidth}
+            height={thumbHeight}
+          />
+          <p>{homeData.value[0].UnparsedAddress}</p>
+          {compareChecked === true && (
+            <>
+              <input
+                type="checkbox"
+                checked={listingCheckBoxes[2]}
+                onChange={() => handleThumbnailCheckOnChange(2)}
+              />
+              <label>Compare</label>
+            </>
+          )}
         </div>
 
-        <div  onClick={open} className='listing-thumbnail'>
-        <img src={homeData.value[0].Media[0].Thumbnail} width={thumbWidth} height={thumbHeight}/>
-        <p>{homeData.value[0].UnparsedAddress}</p>
-        {compareChecked === true && <><input 
-        type="checkbox"
-        checked={listingCheckBoxes[3]}
-        onChange={() => handleThumbnailCheckOnChange(3)}
-        /><label>Compare</label></>}
+        <div onClick={open} className="listing-thumbnail">
+          <img
+            src={homeData.value[0].Media[0].Thumbnail}
+            width={thumbWidth}
+            height={thumbHeight}
+          />
+          <p>{homeData.value[0].UnparsedAddress}</p>
+          {compareChecked === true && (
+            <>
+              <input
+                type="checkbox"
+                checked={listingCheckBoxes[3]}
+                onChange={() => handleThumbnailCheckOnChange(3)}
+              />
+              <label>Compare</label>
+            </>
+          )}
         </div>
-        </div>
-        </>
-    )
+      </div>
+    </>
+  );
 }

--- a/homepare/src/comparisonTable.jsx
+++ b/homepare/src/comparisonTable.jsx
@@ -3,8 +3,8 @@ import { Table } from '@mantine/core'
 
 // useState for array of selected listings and map through those to build table?
 
-export function ComparisonTable () {
-    const rows = dbhomes.homes.map((listing) => (
+export function ComparisonTable ( {homeData} ) {
+    const rows = homeData.map((listing) => (
         <Table.Tr key={listing.id}>
             <Table.Td>{listing.address}</Table.Td>
             <Table.Td>{listing.price}</Table.Td>


### PR DESCRIPTION
You can now select listings and compare them via the comparison table. The listing data is being pulled from homesfromDB.json, but now it's mapped out on our details page and being filtered into the compare table when a user selects a listing. It needs some cosmetic work and to be rendered on dashboard via expanding a collection in my collections, but it works!