### PR TITLE
Updated Collections Detail and switched to Questionnaire

### DIFF
--- a/homepare/package-lock.json
+++ b/homepare/package-lock.json
@@ -5369,9 +5369,9 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.11.tgz",
-      "integrity": "sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
+      "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",

--- a/homepare/src/App.css
+++ b/homepare/src/App.css
@@ -74,8 +74,57 @@ hr.rounded-divider-in-user-collections {
   margin: 15px;
 }
 
+/* this is all buttons right now */
 button {
   border: solid black 2px;
   padding: 3px;
   margin: 5px;
 }
+
+/* Questionnaire CSS */
+
+.div-around-questions-answers-and-buttons-in-questionnaire, .confirm-summary-div-in-questionnaire {
+
+  text-align: center;
+  margin: 0;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  -ms-transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%);
+
+}
+
+.buttons-in-questionnaire {
+  font-size: large;
+  font-weight: 600;
+  padding-left: 10px;
+  padding-right: 10px;
+  margin: 20px
+}
+
+.questions-in-questionnaire {
+  padding: 4px;
+  margin: 5px;
+  margin-bottom: 10px;
+  font-weight: 600;
+}
+
+.questions-in-questionnaire, .answers-in-questionnaire {
+  font-size: larger;  
+}
+
+.confirm-results-list-in-questionnaire {
+  list-style: none;
+}
+
+.confirm-summary-in-questionnaire {
+  font-size: larger;
+  text-align: center;
+}
+
+.confirm-summary-div-in-questionnaire {
+  text-align: center;
+  align-self: center;
+}
+

--- a/homepare/src/App.jsx
+++ b/homepare/src/App.jsx
@@ -82,7 +82,7 @@ function App() {
       />
       <Route
       path="listingInput"
-      element={<Menu><ListingInput token={token} username={username} token={token}/></Menu>}
+      element={<Menu><ListingInput token={token} username={username} /></Menu>}
       />
       <Route
       path="logout"

--- a/homepare/src/CollectionDetail.jsx
+++ b/homepare/src/CollectionDetail.jsx
@@ -4,6 +4,7 @@ import homeData from "./data/homesfromDB.json";
 import { useState } from "react";
 import { useDisclosure } from "@mantine/hooks";
 import { Modal } from "@mantine/core";
+import { Link } from "react-router-dom";
 
 export function CollectionDetail() {
   const thumbWidth = "100px";
@@ -36,16 +37,13 @@ export function CollectionDetail() {
 
   return (
     <>
-      <p>
-        This is the collection detail page, cards containing house image
-        thumbnail and address will be mapped out here
-      </p>
+      <Link to="/"><button>Back to My Collections</button></Link>
       <h1> Collection Title </h1>
       {listingCheckBoxes.find((checkedbox) => checkedbox === true) && <button onClick={open}>Compare</button>}
       <Modal
         opened={opened}
         onClose={close}
-        title="This is a fullscreen modal"
+        title=""
         fullScreen
         radius={0}
         transitionProps={{ transition: "fade", duration: 200 }}
@@ -103,63 +101,6 @@ export function CollectionDetail() {
             </div>
           );
         })}
-
-        {/* <div onClick={thumbnailModalOpen} className="listing-thumbnail">
-          <img
-            src={homeData.homes[1].images[1].Thumbnail}
-            width={thumbWidth}
-            height={thumbHeight}
-          />
-          <p>{homeData.homes[1].address}</p>
-          {compareChecked === true && (
-            <>
-              <input
-                type="checkbox"
-                checked={listingCheckBoxes[1]}
-                onChange={() => handleThumbnailCheckOnChange(1)}
-              />
-              <label>Compare</label>
-            </>
-          )}
-        </div>
-
-        <div onClick={thumbnailModalOpen} className="listing-thumbnail">
-          <img
-            src={homeData.homes[2].images[2].Thumbnail}
-            width={thumbWidth}
-            height={thumbHeight}
-          />
-          <p>{homeData.homes[2].address}</p>
-          {compareChecked === true && (
-            <>
-              <input
-                type="checkbox"
-                checked={listingCheckBoxes[2]}
-                onChange={() => handleThumbnailCheckOnChange(2)}
-              />
-              <label>Compare</label>
-            </>
-          )}
-        </div>
-
-        <div onClick={thumbnailModalOpen} className="listing-thumbnail">
-          <img
-            src={homeData.homes[0].images[0].Thumbnail}
-            width={thumbWidth}
-            height={thumbHeight}
-          />
-          <p>{homeData.homes[0].address}</p>
-          {compareChecked === true && (
-            <>
-              <input
-                type="checkbox"
-                checked={listingCheckBoxes[3]}
-                onChange={() => handleThumbnailCheckOnChange(3)}
-              />
-              <label>Compare</label>
-            </>
-          )}
-        </div> */}
       </div>
     </>
   );

--- a/homepare/src/ListingDetails.jsx
+++ b/homepare/src/ListingDetails.jsx
@@ -1,0 +1,31 @@
+import homeData from "./data/homes.json";
+import { DetailsCard } from "./detailsCard.jsx";
+import { useState } from 'react'
+import { Menu } from "./Menu";
+
+export function ListingDetails() {
+  console.log(homeData);
+
+  const index = []
+
+  // const [index, setIndex] = useState(0)
+
+  return (
+    <>
+      <h1>Listing Details</h1>
+      <DetailsCard
+        streetAddress={homeData.value[0].UnparsedAddress}
+        sqFootage={homeData.value[0].LivingArea}
+        listPrice={homeData.value[0].ListPrice}
+        city={homeData.value[0].City}
+        zipCode={homeData.value[0].PostalCode}
+        thumbnail={homeData.value[0].Media[0].Thumbnail}
+        bedrooms={homeData.value[0].BedroomsTotal}
+        bathrooms={homeData.value[0].BathroomsTotalInteger}
+        propertyType={homeData.value[0].PropertySubType}
+      />
+      <Menu />
+      
+    </>
+  );
+}

--- a/homepare/src/UserCollections.jsx
+++ b/homepare/src/UserCollections.jsx
@@ -1,132 +1,171 @@
-import { CollectionDetail } from './CollectionDetail'
-import { ComparisonTable } from './comparisonTable'
-import homeData from './data/homes.json'
-import { Modal, Button } from '@mantine/core';
-import { useDisclosure } from '@mantine/hooks';
-import { DetailsCard } from './detailsCard';
-import { useEffect, useState } from 'react';
-import axios from 'axios';
+import { CollectionDetail } from "./CollectionDetail";
+import { ComparisonTable } from "./comparisonTable";
+import homeData from "./data/homes.json";
+import { Modal, Button } from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import { DetailsCard } from "./detailsCard";
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import axios from "axios";
 
 export function UserCollections() {
-    const thumbWidth = "100px";
-    const thumbHeight = "100px";
+  const thumbWidth = "100px";
+  const thumbHeight = "100px";
 
-    const [opened, { open, close }] = useDisclosure(false);
+  const [opened, { open, close }] = useDisclosure(false);
+ 
 
-    const handleNewCollectionClick = () => {
-        console.log("new collection button clicked");
-        <Modal opened={opened} onClose={close} centered>
-            <NewCollection />
-        </Modal>
-        
-    }
-//TO DO
+  const handleNewCollectionClick = () => {
+    console.log("new collection button clicked");
+    <Modal opened={opened} onClose={close} centered>
+      <NewCollection />
+    </Modal>;
+  };
 
-// ALTERNATE VIEWS
-// if user has no collections
-// return <h1>"You don't have any collections!"<br></br>Add one <a href={add a collection}>here!</a>"</h1>
-
-//if user clicks 'see more'
-//render collections detail
-
-//Show only 6 listings in the collections scroll before the user has to click see more
-//Possibly change 'see more' to 'see x number of listings'
-// add a 3 dot menu right aligned on the same line as collection name that allows you to EDIT or DELETE the collection
-
-    return (
-        <>
-        <Modal opened={opened} onClose={close} centered>
-            <DetailsCard />
-        </Modal>
-        <div className='collections-wrapper-in-user-collections'>
+  return (
+    <>
+      <Modal opened={opened} onClose={close} centered>
+        <DetailsCard />
+      </Modal>
+      <div className="collections-wrapper-in-user-collections">
         Collection 1 Name
-        <div className='userCollection'>
-        {/* The name of the collection comes directly from the user */}
-        <div onClick={open} className='listing-thumbnail-in-user-collections'>
-        <img src={homeData.value[0].Media[0].Thumbnail} width={thumbWidth} height={thumbHeight}/>
-        <p className='thumbnail-text-in-user-collections'>{homeData.value[0].UnparsedAddress}</p>
-        </div>
-        
-        <div onClick={open} className='listing-thumbnail-in-user-collections'>
-        <img src={homeData.value[1].Media[2].Thumbnail} width={thumbWidth} height={thumbHeight}/>
-        <p className='thumbnail-text-in-user-collections'>{homeData.value[1].UnparsedAddress}</p>
-        </div>
+        <div className="userCollection">
+          {/* The name of the collection comes directly from the user */}
+          <div onClick={open} className="listing-thumbnail-in-user-collections">
+            <img
+              src={homeData.value[0].Media[0].Thumbnail}
+              width={thumbWidth}
+              height={thumbHeight}
+            />
+            <p className="thumbnail-text-in-user-collections">
+              {homeData.value[0].UnparsedAddress}
+            </p>
+          </div>
 
-        <div onClick={open} className='listing-thumbnail-in-user-collections'>
-        <img src={homeData.value[2].Media[5].Thumbnail} width={thumbWidth} height={thumbHeight}/>
-        <p className='thumbnail-text-in-user-collections'>{homeData.value[2].UnparsedAddress}</p>
-        </div>
+          <div onClick={open} className="listing-thumbnail-in-user-collections">
+            <img
+              src={homeData.value[1].Media[2].Thumbnail}
+              width={thumbWidth}
+              height={thumbHeight}
+            />
+            <p className="thumbnail-text-in-user-collections">
+              {homeData.value[1].UnparsedAddress}
+            </p>
+          </div>
 
-        <div onClick={open} className='listing-thumbnail-in-user-collections'>
-        <img src={homeData.value[2].Media[7].Thumbnail} width={thumbWidth} height={thumbHeight}/>
-        <p className='thumbnail-text-in-user-collections'>{homeData.value[2].UnparsedAddress}</p>
-        </div>
-        
-        <div onClick={open} className='listing-thumbnail-in-user-collections'>
-        <img src={homeData.value[0].Media[0].Thumbnail} width={thumbWidth} height={thumbHeight}/>
-        <p className='thumbnail-text-in-user-collections'>{homeData.value[0].UnparsedAddress}</p>
-        </div>
-        
-        <div onClick={open} className='listing-thumbnail-in-user-collections'>
-        <img src={homeData.value[1].Media[2].Thumbnail} width={thumbWidth} height={thumbHeight}/>
-        <p className='thumbnail-text-in-user-collections'>{homeData.value[1].UnparsedAddress}</p>
-        </div>
+          <div onClick={open} className="listing-thumbnail-in-user-collections">
+            <img
+              src={homeData.value[2].Media[5].Thumbnail}
+              width={thumbWidth}
+              height={thumbHeight}
+            />
+            <p className="thumbnail-text-in-user-collections">
+              {homeData.value[2].UnparsedAddress}
+            </p>
+          </div>
 
-        <div onClick={open} className='listing-thumbnail-in-user-collections'>
-        <img src={homeData.value[2].Media[5].Thumbnail} width={thumbWidth} height={thumbHeight}/>
-        <p className='thumbnail-text-in-user-collections'>{homeData.value[2].UnparsedAddress}</p>
-        </div>
+          <div onClick={open} className="listing-thumbnail-in-user-collections">
+            <img
+              src={homeData.value[2].Media[7].Thumbnail}
+              width={thumbWidth}
+              height={thumbHeight}
+            />
+            <p className="thumbnail-text-in-user-collections">
+              {homeData.value[2].UnparsedAddress}
+            </p>
+          </div>
 
-        <div onClick={open} className='listing-thumbnail-in-user-collections'>
-        <img src={homeData.value[2].Media[7].Thumbnail} width={thumbWidth} height={thumbHeight}/>
-        <p className='thumbnail-text-in-user-collections'>{homeData.value[2].UnparsedAddress}</p>
-        </div>
+          <div onClick={open} className="listing-thumbnail-in-user-collections">
+            <img
+              src={homeData.value[0].Media[0].Thumbnail}
+              width={thumbWidth}
+              height={thumbHeight}
+            />
+            <p className="thumbnail-text-in-user-collections">
+              {homeData.value[0].UnparsedAddress}
+            </p>
+          </div>
 
-        </div>
+          <div onClick={open} className="listing-thumbnail-in-user-collections">
+            <img
+              src={homeData.value[1].Media[2].Thumbnail}
+              width={thumbWidth}
+              height={thumbHeight}
+            />
+            <p className="thumbnail-text-in-user-collections">
+              {homeData.value[1].UnparsedAddress}
+            </p>
+          </div>
 
-        <p className='see-more-in-user-collections'>See More</p>
+          <div onClick={open} className="listing-thumbnail-in-user-collections">
+            <img
+              src={homeData.value[2].Media[5].Thumbnail}
+              width={thumbWidth}
+              height={thumbHeight}
+            />
+            <p className="thumbnail-text-in-user-collections">
+              {homeData.value[2].UnparsedAddress}
+            </p>
+          </div>
+
+          <div onClick={open} className="listing-thumbnail-in-user-collections">
+            <img
+              src={homeData.value[2].Media[7].Thumbnail}
+              width={thumbWidth}
+              height={thumbHeight}
+            />
+            <p className="thumbnail-text-in-user-collections">
+              {homeData.value[2].UnparsedAddress}
+            </p>
+          </div>
+        </div>
+        <Link to="/CollectionDetail">See More</Link>
         {/* See more should pull up collection details */}
-        </div>
-        <hr className="rounded-divider-in-user-collections"></hr>
-        
-        <div className='collections-wrapper-in-user-collections'>
-        </div>
-        {/* <CollectionDetail />
+      </div>
+      <hr className="rounded-divider-in-user-collections"></hr>
+
+      <div className="collections-wrapper-in-user-collections"></div>
+      {/* <CollectionDetail />
         <ComparisonTable /> */}
-        
-        <NewCollection />
-        </>
-    )
+
+      <NewCollection />
+    </>
+  );
 }
-// I would like for the new collection form to be in a modal that pops up but I can't figure that out in this moment. I think it's because there is already a modal on that component for the detailsCard - Freddie 
+// I would like for the new collection form to be in a modal that pops up but I can't figure that out in this moment. I think it's because there is already a modal on that component for the detailsCard - Freddie
 
 export function NewCollection() {
-    const [collectionInput, setCollectionInput] = useState("")
+  const [collectionInput, setCollectionInput] = useState("");
 
-    const handleSaveCollection = (e) => {
-        console.log("save button clicked")
-        console.log(collectionInput)
-        e.preventDefault()
-        axios.post('https://homepare-backend.onrender.com/collections', {
-            search_name: collectionInput
-        }, {
-            headers: {
-                authorization: "x-access-token eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6Im5ld3VzZXI5IiwiaWF0IjoxNzA1NTk1NDY5LCJleHAiOjE3MDU2ODE4Njl9.S1kPErLtGajmty_NF5sOUEle56onmCjpZ9svk-K1eOc"
-            }
-        })
-    }
+  const handleSaveCollection = (e) => {
+    console.log("save button clicked");
+    console.log(collectionInput);
+    e.preventDefault();
+    axios.post(
+      "https://homepare-backend.onrender.com/collections",
+      {
+        search_name: collectionInput,
+      },
+      {
+        headers: {
+          authorization:
+            "x-access-token eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6Im5ld3VzZXI5IiwiaWF0IjoxNzA1NTk1NDY5LCJleHAiOjE3MDU2ODE4Njl9.S1kPErLtGajmty_NF5sOUEle56onmCjpZ9svk-K1eOc",
+        },
+      }
+    );
+  };
 
-    return (
-        <>
-        <form onSubmit={handleSaveCollection} >
-            <input 
-                type='text'
-                placeholder='Name your new collection'
-                onChange={(e)=>setCollectionInput(e.target.value)}
-                value={collectionInput}
-            />
-            <button type="submit">Save</button>
-        </form>
-        </>
-    )
+  return (
+    <>
+      <form onSubmit={handleSaveCollection}>
+        <input
+          type="text"
+          placeholder="Name your new collection"
+          onChange={(e) => setCollectionInput(e.target.value)}
+          value={collectionInput}
+        />
+        <button type="submit">Save</button>
+      </form>
+    </>
+  );
 }

--- a/homepare/src/dashboard.jsx
+++ b/homepare/src/dashboard.jsx
@@ -26,7 +26,7 @@ export function Dashboard( {myListings, token} ) {
         <Tabs.Tab value={TABNAMES.MY_LISTINGS}>My Listings</Tabs.Tab>
         <Tabs.Tab value={TABNAMES.MY_COLLECTIONS}>My Collections</Tabs.Tab>
       </Tabs.List>
-      </Tabs> 
+      </Tabs>
       </div>
         {activeTab === TABNAMES.MY_LISTINGS && <UserListings token={token}
         myListings={myListings}

--- a/homepare/src/questionnaire.jsx
+++ b/homepare/src/questionnaire.jsx
@@ -46,14 +46,6 @@ export function Questionnaire( {token}) {
   };
 
   const handleConfirmClick = () => {
-    console.log("confirm click");
-    console.log("recordedanswers", recordedAnswers);
-    //if this is the last question
-    //index === questionnaireData.length - 1
-    //show this button
-    // when this button is clicked
-    // post recorded answers to the back end
-
     axios
       .post("https://homepare-backend.onrender.com/user-preference", {
         address: null,
@@ -69,7 +61,6 @@ export function Questionnaire( {token}) {
         }
       })
       .then((result) => {
-        console.log("result", result);
         navigate("/");
       });
     // .catch((error) => setError(error.response.data.))
@@ -79,25 +70,30 @@ export function Questionnaire( {token}) {
     <>
       {index === questionnaireData.length ? (
         <>
-          <h1>You are looking for a:</h1>
+          {/* <h1>You are looking for a:</h1>
           {recordedAnswers.map((answerObject) => (
             <>
-              <li>{answerObject.text}</li>
+              <li className="confirm-results-list-in-questionnaire">{answerObject.text}</li>
             </>
-          ))}
-          <button onClick={handleConfirmClick}>Confirm</button>
+          ))} */}
+          <div className="confirm-summary-div-in-questionnaire">
+          <p className="confirm-summary-in-questionnaire">You are looking for a <b>{recordedAnswers[0].text}</b>, <b>{recordedAnswers[1].text}</b> home <b>{recordedAnswers[2].text}</b>, <b>{recordedAnswers[3].text}</b>, and <b>{recordedAnswers[4].text}</b>.</p>
+          <br></br>
+          <button className="buttons-in-questionnaire" onClick={handleBackClick}>Back</button>
+          <button className="buttons-in-questionnaire" onClick={handleConfirmClick}>Confirm</button>
+          </div>
         </>
       ) : (
         <>
-          <h1>Questonnaire</h1>
+        <div className="div-around-questions-answers-and-buttons-in-questionnaire">
           <form>
-            <h3>{questionnaireData[index].question}</h3>
+            <p className="questions-in-questionnaire">{questionnaireData[index].question}</p>
             {questionnaireData[index].answers.map((answerObject) => {
               console.log(answerObject);
               return (
                 // eslint-disable-next-line react/jsx-key
                 <div>
-                  <label>
+                  <label className="answers-in-questionnaire">
                     <input
                       type="radio"
                       value={answerObject.value}
@@ -111,15 +107,18 @@ export function Questionnaire( {token}) {
               );
             })}
           </form>
+          {index != 0 && <button className="buttons-in-questionnaire" onClick={handleBackClick}>Back</button>}
           {
             <button
               onClick={handleNextClick}
-              disabled={selectedAnswer ? false : true}
+              disabled={selectedAnswer.value ? false : true}
+              className="buttons-in-questionnaire"
             >
               Next
             </button>
           }
-          {index != 0 && <button onClick={handleBackClick}>Back</button>}
+          
+          </div>
         </>
       )}
     </>


### PR DESCRIPTION
These are the changes:

- Removed a duplicate token in the listing input route in app.jsx
- Collections navigates to collections detail when ‘see more’ is clicked
- Collections detail has a back button that navigates back to user collections
- Next button in questionnaire is back to being disabled if no answer is selected
- Back button in questionnaire now appears at the end alongside confirm
- Questionnaire results in questionnaire are now a readable phrase instead of a list, the original list is just commented out in case we want to restore it and display it that way
- Updated the CSS for questionnaire: buttons are centered, all content is padded, all text is larger, all content is centered vertically and horizontally on the page