### PR TITLE
Updated flow for collection listing comparisons

### DIFF
--- a/homepare/src/App.css
+++ b/homepare/src/App.css
@@ -34,8 +34,9 @@ div.userCollection {
   white-space: nowrap;
 }
 
-.see-more-in-user-collections {
+.compare-listings-in-user-collections {
   text-align: right;
+  text-decoration: underline;
 }
 
 .collections-wrapper-in-user-collections {

--- a/homepare/src/CollectionDetail.jsx
+++ b/homepare/src/CollectionDetail.jsx
@@ -10,7 +10,6 @@ export function CollectionDetail() {
   const thumbWidth = "100px";
   const thumbHeight = "100px";
 
-  const [compareChecked, setCompareChecked] = useState(false);
   const [listingCheckBoxes, setlistingCheckBoxes] = useState(
     new Array(homeData.homes.length).fill(false)
   );
@@ -22,9 +21,6 @@ export function CollectionDetail() {
   const [opened, { open, close }] = useDisclosure(false);
   //this useDisclosure is for Mantine
 
-  const handleCheckChange = () => {
-    setCompareChecked(!compareChecked);
-  };
 
   const handleThumbnailCheckOnChange = (listingIndex) => {
     const updatedListingCheckBoxes = listingCheckBoxes.map((listing, index) =>
@@ -57,21 +53,14 @@ export function CollectionDetail() {
   />
       </Modal>
       <br></br>
-      <input
-        type="checkbox"
-        checked={compareChecked}
-        onChange={handleCheckChange}
-      />
-      <label>Compare?</label>
-      {!compareChecked && (
-        <Modal
+
+        {/* <Modal
           opened={thumbnailModalOpened}
           onClose={thumbnailModalClose}
           centered
         >
           <DetailsCard />
-        </Modal>
-      )}
+        </Modal> */}
 
       <div className="thumnail-grid-in-collections-detail">
         {homeData.homes.map((listing, index) => {
@@ -88,7 +77,6 @@ export function CollectionDetail() {
                 height={thumbHeight}
               />
               <p>{listing.address}</p>
-              {compareChecked === true && (
                 <>
                   <input
                     type="checkbox"
@@ -97,7 +85,6 @@ export function CollectionDetail() {
                   />
                   <label>Compare</label>
                 </>
-              )}
             </div>
           );
         })}

--- a/homepare/src/UserCollections.jsx
+++ b/homepare/src/UserCollections.jsx
@@ -121,7 +121,7 @@ export function UserCollections( {token}) {
             </p>
           </div>
         </div>
-        <Link to="/CollectionDetail"><p className="see-more-in-user-collections">See More</p></Link>
+        <Link to="/CollectionDetail"><p className="compare-listings-in-user-collections">Compare Listings?</p></Link>
         {/* See more should pull up collection details */}
       <Divider size="xs" />
       </div>


### PR DESCRIPTION
- Changed "See More" in User Collections to "Compare Listings"
- Removed 'Compare?' checkbox in Collections Detail + state that goes with it
- Commented out the thumbnail modal in collections detail (it was getting too annoying) with comparison checkboxes