### PR TITLE
placed hamburger menu beside HomePare logo on dashboard, also changed…

### DIFF
--- a/homepare/src/App.jsx
+++ b/homepare/src/App.jsx
@@ -38,7 +38,7 @@ function App() {
     <Routes> 
       <Route 
         path="/"
-        element={!token ? <Navigate to="/login" /> : <Menu><Dashboard token={token} /></Menu>}
+        element={!token ? <Navigate to="/login" /> : <Dashboard token={token} />}
         />
       <Route
         path="/register"

--- a/homepare/src/Menu.jsx
+++ b/homepare/src/Menu.jsx
@@ -11,9 +11,8 @@ export function Menu({children}) {
         <>
         <MantineMenu width={200}>
         <MantineMenu.Target> 
-        <Burger opened={opened} onClick={toggle} aria-label="Toggle navigation" />
+        <Burger onClick={toggle} aria-label="Toggle navigation" />
         </MantineMenu.Target>
-
         <MantineMenu.Dropdown>
             <Link to="/">
                 <MantineMenu.Item leftSection={<IconHomeHeart size={25} />}>

--- a/homepare/src/dashboard.jsx
+++ b/homepare/src/dashboard.jsx
@@ -36,6 +36,7 @@ export function Dashboard( {token} ) {
     <div>
 {/* The Group Below is the HomePare Title and Logo */}
 <Group>
+  <Menu></Menu>
     <IconHomeCheck color="var(--mantine-color-dark-4)" size={48} />
     <Title c="var(--mantine-color-dark-4)" order={1} fw="900">
       Home<Text span c="#00A6BA" inherit>Pare</Text>

--- a/homepare/src/logo.jsx
+++ b/homepare/src/logo.jsx
@@ -1,0 +1,12 @@
+import { Group, Title, Text } from "@mantine/core"
+import { IconHomeCheck } from "@tabler/icons-react"
+
+export function Logo() {
+    return (
+        <Group align="left-start">
+        <IconHomeCheck color="var(--mantine-color-dark-4)" size={48} />
+        <Title c="var(--mantine-color-dark-4)" order={1} fw="900">Home<Text span c="#00A6BA" inherit>Pare</Text>
+        </Title>
+    </Group>
+    )
+}


### PR DESCRIPTION
… opened={opened} inside of the hamburger menu so the X no longer toggles and we always have just the hamburger menu