### PR TITLE
Polishing up Questionnaire + Dashboard

### DIFF
--- a/homepare/src/UserCollections.jsx
+++ b/homepare/src/UserCollections.jsx
@@ -29,15 +29,15 @@ export function UserCollections({ token }) {
       });
   }, [token]);
 
-  if (myCollections.length != 0 ){
-
-  if (myCollections[0].search_name === "My List") {
-    myCollections[0].search_name = "My Homes"
-  }}
+  if (myCollections.length != 0) {
+    if (myCollections[0].search_name === "My List") {
+      myCollections[0].search_name = "My Homes";
+    }
+  }
 
   return (
     <>
-    <NewCollection token={token} />
+      <NewCollection token={token} />
       {errorMessage && <Text c="red">{errorMessage}</Text>}
       {myCollections.map((collection, index) => {
         index += 1;
@@ -60,8 +60,6 @@ export function UserCollections({ token }) {
           </>
         );
       })}
-
-      
     </>
   );
 }
@@ -131,41 +129,47 @@ export function CollectionListings({ token, index, thumbHeight, thumbWidth }) {
               />
             )}
           </Modal>
-
-          {collectionListings.map((coListing) => {
-            return (
-              <Box
-                mah={200}
-                p="xs"
-                className="listing-thumbnail-in-user-collections"
-                style={{ "--radius": "0.5rem", borderRadius: "var(--radius)" }}
-                key={coListing._id}
-                onClick={() => handleModalOpen(coListing)}
-              >
-                <Group>
-                  {coListing.images &&
-                    coListing.images.length > 0 &&
-                    Object.keys(coListing.images[0]).length > 0 && (
-                      <img
-                        src={coListing.images[0][0]}
-                        onError={usePlaceHolder}
-                        width={thumbWidth}
-                        height={thumbHeight}
-                      />
+          {collectionListings.length === 0 ? (
+            <Text>Add a listing!</Text>
+          ) : (
+            collectionListings.map((coListing) => {
+              return (
+                <Box
+                  mah={200}
+                  p="xs"
+                  className="listing-thumbnail-in-user-collections"
+                  style={{
+                    "--radius": "0.5rem",
+                    borderRadius: "var(--radius)",
+                  }}
+                  key={coListing._id}
+                  onClick={() => handleModalOpen(coListing)}
+                >
+                  <Group>
+                    {coListing.images &&
+                      coListing.images.length > 0 &&
+                      Object.keys(coListing.images[0]).length > 0 && (
+                        <img
+                          src={coListing.images[0][0]}
+                          onError={usePlaceHolder}
+                          width={thumbWidth}
+                          height={thumbHeight}
+                        />
+                      )}
+                    {coListing.images && coListing.images.length === 0 && (
+                      <img src={placeholderImage} />
                     )}
-                  {coListing.images && coListing.images.length === 0 && (
-                    <img src={placeholderImage} />
-                  )}
-                  <Text
-                    className="thumbnail-text-in-user-collections"
-                    truncate="end"
-                  >
-                    {coListing.address}
-                  </Text>
-                </Group>
-              </Box>
-            );
-          })}
+                    <Text
+                      className="thumbnail-text-in-user-collections"
+                      truncate="end"
+                    >
+                      {coListing.address}
+                    </Text>
+                  </Group>
+                </Box>
+              );
+            })
+          )}
         </Box>
       )}
       <Link to="/CollectionDetail" state={collectionListings}>

--- a/homepare/src/UserCollections.jsx
+++ b/homepare/src/UserCollections.jsx
@@ -3,9 +3,10 @@ import { DetailsCard } from "./detailsCard";
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import axios from "axios";
-import { Divider, Text, Modal, Group, Box } from "@mantine/core";
+import { Divider, Text, Modal, Group, Box, Title } from "@mantine/core";
 import placeholderImage from "./data/pexels-kelly-2950003.jpg";
 import { NewCollection } from "./NewCollection";
+import { IconHomePlus } from '@tabler/icons-react';
 
 export function UserCollections({ token }) {
   const thumbWidth = "100px";
@@ -130,7 +131,21 @@ export function CollectionListings({ token, index, thumbHeight, thumbWidth }) {
             )}
           </Modal>
           {collectionListings.length === 0 ? (
-            <Text>Add a listing!</Text>
+            <Box
+              justify="center"
+              mah={200}
+              p="xs"
+              className="listing-thumbnail-in-user-collections"
+              style={{
+                "--radius": "0.5rem",
+                borderRadius: "var(--radius)",
+              }}
+            >
+              <Link to="/listingInput">
+                <IconHomePlus color="var(--mantine-color-dark-4)" size={40} />
+              <Text ta="center" size="sm">Add a listing!</Text>
+              </Link>
+            </Box>
           ) : (
             collectionListings.map((coListing) => {
               return (

--- a/homepare/src/questionnaire.jsx
+++ b/homepare/src/questionnaire.jsx
@@ -74,11 +74,11 @@ export function Questionnaire( {token}) {
         <>
           <div className="confirm-summary-div-in-questionnaire">
           <Group justify="center">
-          <Title order={3}>You are looking for a home with <Text span td="underline" inherit>{recordedAnswers[0].text}</Text>, <Text span td="underline" inherit>{recordedAnswers[1].text}</Text>, <Text span td="underline" inherit>{recordedAnswers[2].text}</Text>, and <Text span td="underline" inherit>{recordedAnswers[3].text}</Text>.
+          <Title fw={500} order={3}>You are looking for a home with <br></br><Text span td="underline" inherit>{recordedAnswers[0].text}</Text>,<br></br> <Text span td="underline" inherit>{recordedAnswers[1].text}</Text>,<br></br> <Text span td="underline" inherit>{recordedAnswers[2].text}</Text>, and <Text span td="underline" inherit>{recordedAnswers[3].text}</Text>.
           </Title>
-          <Button my={4} size="md" leftSection={<IconArrowLeft size={14} />} onClick={handleBackClick}>Back</Button>
-          <Button onClick={handleConfirmClick} size="md" variant="light" leftSection={<IconCheckbox size={14} />}>Confirm</Button>
-    </Group>
+          </Group>
+          <Button my={4} size="sm" mt="sm" leftSection={<IconArrowLeft size={14} />} onClick={handleBackClick}>Back</Button>
+          <Button onClick={handleConfirmClick} size="sm" variant="light" mt="xs" ml="sm" leftSection={<IconCheckbox size={14} />}>Confirm</Button>
           </div>
         </>
       ) : (
@@ -106,11 +106,11 @@ export function Questionnaire( {token}) {
             })}
           </form>
           <Group justify="center" style={{ marginTop: 20 }}>
-          {index != 0 && <Button size="md" leftSection={<IconArrowLeft size={14} />} onClick={handleBackClick}>Back</Button>}
+          {index != 0 && <Button size="sm" leftSection={<IconArrowLeft size={14} />} onClick={handleBackClick}>Back</Button>}
           {
             <Button
               onClick={handleNextClick}
-              size="md"
+              size="sm"
               rightSection={<IconArrowRight size={14} />}
               disabled={selectedAnswer.value ? false : true}
               variant="light"


### PR DESCRIPTION
- Added listing placeholder if there are no listings in collections on dashboard
- fixed buttons in questionnaire so they're inline on mobile
- fixed confirm text at end of questionnaire so it's displaying more like a list and not so aggressively bolded